### PR TITLE
allow for elm-css 14

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "13.0.0 <= v < 14.0.0"
+        "rtfeldman/elm-css": "13.0.0 <= v < 15.0.0"
     },
     "elm-version": "0.18.0 <= v <= 0.18.0"
 }


### PR DESCRIPTION
elm-css 14.0.0 has been released. I don't believe it changes anything that affects this package, so 13 and 14 should both be valid options here, but it does include a change which makes it work better with this package, see: https://github.com/rtfeldman/elm-css/pull/420

see: https://github.com/rtfeldman/elm-css/blob/master/CHANGELOG.md

changes in 14 don't affect this package's consumption of the library