### PR TITLE
Re-add tests

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -21,5 +21,7 @@
         "elm/json": "1.0.0 <= v < 2.0.0",
         "rtfeldman/elm-css": "15.1.0 <= v < 16.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.1 <= v < 2.0.0"
+    }
 }

--- a/tests/Accessibility/AriaSpec.elm
+++ b/tests/Accessibility/AriaSpec.elm
@@ -1,0 +1,66 @@
+module Accessibility.AriaSpec exposing (spec)
+
+import Accessibility.Styled.Aria exposing (..)
+import SpecHelpers exposing (..)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Accessibility.Aria"
+        [ test "labelledBy" <|
+            expectAria ( labelledBy, "label-id" ) ( "labelledby", "label-id" )
+        , test "labeledBy" <|
+            expectAria ( labeledBy, "label-id" ) ( "labelledby", "label-id" )
+        , test "longDescription" <|
+            expectAttribute ( longDescription, "element-id" ) ( "longdesc", "element-id" )
+        , test "activeDescendant" <|
+            expectAria ( activeDescendant, "element-id" ) ( "activedescendant", "element-id" )
+        , test "colCount" <|
+            expectAria ( colCount, 15 ) ( "colcount", "15" )
+        , test "colIndex" <|
+            expectAria ( colIndex, 15 ) ( "colindex", "15" )
+        , test "colSpan" <|
+            expectAria ( colSpan, 15 ) ( "colspan", "15" )
+        , test "controls" <|
+            expectAria ( controls, "controlled-element-id" ) ( "controls", "controlled-element-id" )
+        , describe "currentItem" <|
+            expectAriaBoolAttribute currentItem "current"
+        , test "currentPage" <|
+            expectAria ( \() -> currentPage, () ) ( "current", "page" )
+        , test "currentStep" <|
+            expectAria ( \() -> currentStep, () ) ( "current", "step" )
+        , test "currentLocation" <|
+            expectAria ( \() -> currentLocation, () ) ( "current", "location" )
+        , test "currentDate" <|
+            expectAria ( \() -> currentDate, () ) ( "current", "date" )
+        , test "currentTime" <|
+            expectAria ( \() -> currentTime, () ) ( "current", "time" )
+        , test "describedBy" <|
+            expectAria ( describedBy, [ "some-value", "some-other-value" ] )
+                ( "describedby", "some-value some-other-value" )
+        , test "details" <|
+            expectAria ( details, "element-id" ) ( "details", "element-id" )
+        , test "errorMessage" <|
+            expectAria ( errorMessage, "element-id" ) ( "errormessage", "element-id" )
+        , test "flowTo" <|
+            expectAria ( flowTo, [ "element-id", "some-other-element-id" ] )
+                ( "flowto", "element-id some-other-element-id" )
+        , test "keyShortcuts" <|
+            expectAria ( keyShortcuts, [ "Alt+Shift+P", "Control+F" ] )
+                ( "keyshortcuts", "Alt+Shift+P Control+F" )
+        , test "placeholder" <|
+            expectAria ( placeholder, "element-id" ) ( "placeholder", "element-id" )
+        , test "posInSet" <|
+            expectAria ( posInSet, 15 ) ( "posinset", "15" )
+        , test "roleDescription" <|
+            expectAria ( roleDescription, "element-id" ) ( "roledescription", "element-id" )
+        , test "rowCount" <|
+            expectAria ( rowCount, 15 ) ( "rowcount", "15" )
+        , test "rowIndex" <|
+            expectAria ( rowIndex, 15 ) ( "rowindex", "15" )
+        , test "rowSpan" <|
+            expectAria ( rowSpan, 15 ) ( "rowspan", "15" )
+        , test "setSize" <|
+            expectAria ( setSize, 15 ) ( "setsize", "15" )
+        ]

--- a/tests/Accessibility/KeySpec.elm
+++ b/tests/Accessibility/KeySpec.elm
@@ -1,0 +1,137 @@
+module Accessibility.KeySpec exposing (spec)
+
+import Accessibility.Styled.Key exposing (..)
+import Html.Styled exposing (..)
+import Json.Encode as Encode
+import SpecHelpers exposing (expectAttribute)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+
+
+spec : Test
+spec =
+    describe "Accessibility.Key"
+        [ describe "tabbable" tabbableSpec
+        , describe "keys" keys
+        ]
+
+
+tabbableSpec : List Test
+tabbableSpec =
+    [ test "tabbable True" <|
+        expectAttribute ( tabbable, True ) ( "tabIndex", "0" )
+    , test "tabbable False" <|
+        expectAttribute ( tabbable, False ) ( "tabIndex", "-1" )
+    ]
+
+
+keys : List Test
+keys =
+    [ expectEvent "left key" (withKey 37) Left
+    , expectEvent "up key" (withKey 38) Up
+    , expectEvent "right key" (withKey 39) Right
+    , expectEvent "down key" (withKey 40) Down
+    , expectEvent "enter key" (withKey 13) Enter
+    , expectEvent "spacebar" (withKey 32) SpaceBar
+    , expectEvent "tab key" (withKey 9) Tab
+    , expectEvent "tab+shift" (withShiftAndKey 9) TabBack
+    , expectEvent "escape key" (withKey 27) Escape
+    ]
+
+
+expectEvent : String -> Encode.Value -> Msg -> Test
+expectEvent name keyState msg =
+    test (name ++ " produces " ++ msgToString msg) <|
+        \() ->
+            view
+                |> toUnstyled
+                |> Query.fromHtml
+                |> Event.simulate (keydown keyState)
+                |> Event.expect msg
+
+
+keydown : Encode.Value -> ( String, Encode.Value )
+keydown =
+    Event.custom "keydown"
+
+
+withKey : Int -> Encode.Value
+withKey keycode =
+    Encode.object [ keyCode keycode, shiftKey False ]
+
+
+withShiftAndKey : Int -> Encode.Value
+withShiftAndKey keycode =
+    Encode.object [ keyCode keycode, shiftKey True ]
+
+
+keyCode : Int -> ( String, Encode.Value )
+keyCode keycode =
+    ( "keyCode", Encode.int keycode )
+
+
+shiftKey : Bool -> ( String, Encode.Value )
+shiftKey pressed =
+    ( "shiftKey", Encode.bool pressed )
+
+
+view : Html Msg
+view =
+    div
+        [ onKeyDown
+            [ left Left
+            , up Up
+            , right Right
+            , down Down
+            , enter Enter
+            , tab Tab
+            , tabBack TabBack
+            , space SpaceBar
+            , escape Escape
+            ]
+        ]
+        []
+
+
+type Msg
+    = Left
+    | Up
+    | Right
+    | Down
+    | Enter
+    | Tab
+    | TabBack
+    | SpaceBar
+    | Escape
+
+
+msgToString : Msg -> String
+msgToString msg =
+    case msg of
+        Left ->
+            "Left"
+
+        Up ->
+            "Up"
+
+        Right ->
+            "Right"
+
+        Down ->
+            "Down"
+
+        Enter ->
+            "Enter"
+
+        Tab ->
+            "Tab"
+
+        TabBack ->
+            "TabBack"
+
+        SpaceBar ->
+            "SpaceBar"
+
+        Escape ->
+            "Escape"

--- a/tests/Accessibility/LandmarkSpec.elm
+++ b/tests/Accessibility/LandmarkSpec.elm
@@ -1,0 +1,39 @@
+module Accessibility.LandmarkSpec exposing (spec)
+
+import Accessibility.Styled as Html
+import Accessibility.Styled.Landmark exposing (..)
+import Html.Attributes
+import Html.Styled exposing (toUnstyled)
+import Json.Encode
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+spec : Test
+spec =
+    describe "Accessibility.Landmark" <|
+        List.map (\( a, b ) -> addsRole a b)
+            [ ( application, "application" )
+            , ( banner, "banner" )
+            , ( complementary, "complementary" )
+            , ( contentInfo, "contentinfo" )
+            , ( form, "form" )
+            , ( main_, "main" )
+            , ( navigation, "navigation" )
+            , ( region, "region" )
+            , ( search, "search" )
+            ]
+
+
+addsRole : Html.Attribute Never -> String -> Test
+addsRole role_ expected =
+    test ("sets the role attribute: " ++ expected) <|
+        \() ->
+            Html.div [] [ Html.div [ role_ ] [] ]
+                |> toUnstyled
+                |> Query.fromHtml
+                |> Query.has
+                    [ Selector.attribute <|
+                        Html.Attributes.property "role" (Json.Encode.string expected)
+                    ]

--- a/tests/Accessibility/LiveSpec.elm
+++ b/tests/Accessibility/LiveSpec.elm
@@ -1,0 +1,29 @@
+module Accessibility.LiveSpec exposing (spec)
+
+import Accessibility.Styled.Live exposing (..)
+import SpecHelpers exposing (..)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Accessibility.Aria"
+        [ describe "atomic" <|
+            expectAriaBoolAttribute atomic "atomic"
+        , describe "busy" <|
+            expectAriaBoolAttribute busy "busy"
+        , test "livePolite" <|
+            expectAria ( \() -> livePolite, () ) ( "live", "polite" )
+        , test "liveAssertive" <|
+            expectAria ( \() -> liveAssertive, () ) ( "live", "assertive" )
+        , test "relevantAdditions" <|
+            expectAria ( \() -> relevantAdditions, () ) ( "relevant", "additions" )
+        , test "relevantAdditionsText" <|
+            expectAria ( \() -> relevantAdditionsText, () ) ( "relevant", "additions text" )
+        , test "relevantAll" <|
+            expectAria ( \() -> relevantAll, () ) ( "relevant", "all" )
+        , test "relevantRemovals" <|
+            expectAria ( \() -> relevantRemovals, () ) ( "relevant", "removals" )
+        , test "relevantText" <|
+            expectAria ( \() -> relevantText, () ) ( "relevant", "text" )
+        ]

--- a/tests/Accessibility/RoleSpec.elm
+++ b/tests/Accessibility/RoleSpec.elm
@@ -1,0 +1,82 @@
+module Accessibility.RoleSpec exposing (spec)
+
+import Accessibility.Styled as Html
+import Accessibility.Styled.Role exposing (..)
+import Html.Attributes
+import Html.Styled exposing (toUnstyled)
+import Json.Encode
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+spec : Test
+spec =
+    describe "Accessibility.Role" <|
+        List.map (\( a, b ) -> addsRole a b)
+            [ ( alert, "alert" )
+            , ( alertDialog, "alertdialog" )
+            , ( article, "article" )
+            , ( button, "button" )
+            , ( checkBox, "checkbox" )
+            , ( columnHeader, "columnheader" )
+            , ( comboBox, "combobox" )
+            , ( definition, "definition" )
+            , ( dialog, "dialog" )
+            , ( directory, "directory" )
+            , ( document, "document" )
+            , ( grid, "grid" )
+            , ( gridCell, "gridcell" )
+            , ( group, "group" )
+            , ( heading, "heading" )
+            , ( img, "img" )
+            , ( link, "link" )
+            , ( list, "list" )
+            , ( listBox, "listbox" )
+            , ( listItem, "listitem" )
+            , ( log, "log" )
+            , ( marquee, "marquee" )
+            , ( math, "math" )
+            , ( menu, "menu" )
+            , ( menuBar, "menubar" )
+            , ( menuItem, "menuitem" )
+            , ( menuItemCheckBox, "menuitemcheckbox" )
+            , ( menuItemRadio, "menuitemradio" )
+            , ( note, "note" )
+            , ( option, "option" )
+            , ( presentation, "presentation" )
+            , ( progressBar, "progressbar" )
+            , ( radio, "radio" )
+            , ( radioGroup, "radiogroup" )
+            , ( row, "row" )
+            , ( rowGroup, "rowgroup" )
+            , ( rowHeader, "rowheader" )
+            , ( scrollBar, "scrollbar" )
+            , ( separator, "separator" )
+            , ( slider, "slider" )
+            , ( spinButton, "spinbutton" )
+            , ( status, "status" )
+            , ( tab, "tab" )
+            , ( tabList, "tablist" )
+            , ( tabPanel, "tabpanel" )
+            , ( textBox, "textbox" )
+            , ( timer, "timer" )
+            , ( toolBar, "toolbar" )
+            , ( toolTip, "tooltip" )
+            , ( tree, "tree" )
+            , ( treeGrid, "treegrid" )
+            , ( treeItem, "treeitem" )
+            ]
+
+
+addsRole : Html.Attribute Never -> String -> Test
+addsRole role_ expected =
+    test ("sets the role attribute: " ++ expected) <|
+        \() ->
+            Html.div [] [ Html.div [ role_ ] [] ]
+                |> toUnstyled
+                |> Query.fromHtml
+                |> Query.has
+                    [ Selector.attribute <|
+                        Html.Attributes.property "role" (Json.Encode.string expected)
+                    ]

--- a/tests/Accessibility/WidgetSpec.elm
+++ b/tests/Accessibility/WidgetSpec.elm
@@ -1,0 +1,79 @@
+module Accessibility.WidgetSpec exposing (spec)
+
+import Accessibility.Styled.Widget exposing (..)
+import SpecHelpers exposing (..)
+import Test exposing (..)
+
+
+spec : Test
+spec =
+    describe "Accessibility.Widget"
+        [ test "autoCompleteInline" <|
+            expectAria ( \() -> autoCompleteInline, () ) ( "autocomplete", "inline" )
+        , test "autoCompleteList" <|
+            expectAria ( \() -> autoCompleteList, () ) ( "autocomplete", "list" )
+        , test "autoCompleteBoth" <|
+            expectAria ( \() -> autoCompleteBoth, () ) ( "autocomplete", "both" )
+        , test "hasMenuPopUp" <|
+            expectAria ( \() -> hasMenuPopUp, () ) ( "haspopup", "menu" )
+        , test "hasListBoxPopUp" <|
+            expectAria ( \() -> hasListBoxPopUp, () ) ( "haspopup", "listbox" )
+        , test "hasTreePopUp" <|
+            expectAria ( \() -> hasTreePopUp, () ) ( "haspopup", "tree" )
+        , test "hasGridPopUp" <|
+            expectAria ( \() -> hasGridPopUp, () ) ( "haspopup", "grid" )
+        , test "hasDialogPopUp" <|
+            expectAria ( \() -> hasDialogPopUp, () ) ( "haspopup", "dialog" )
+        , test "invalidGrammar" <|
+            expectAria ( \() -> invalidGrammar, () ) ( "invalid", "grammar" )
+        , test "invalidSpelling" <|
+            expectAria ( \() -> invalidSpelling, () ) ( "invalid", "spelling" )
+        , test "orientationHorizontal" <|
+            expectAria ( \() -> orientationHorizontal, () ) ( "orientation", "horizontal" )
+        , test "orientationVertical" <|
+            expectAria ( \() -> orientationVertical, () ) ( "orientation", "vertical" )
+        , test "sortAscending" <|
+            expectAria ( \() -> sortAscending, () ) ( "sort", "ascending" )
+        , test "sortDescending" <|
+            expectAria ( \() -> sortDescending, () ) ( "sort", "descending" )
+        , test "sortCustom" <|
+            expectAria ( \() -> sortCustom, () ) ( "sort", "other" )
+        , test "sortNone" <|
+            expectAria ( \() -> sortNone, () ) ( "sort", "none" )
+        , test "label" <|
+            expectAria ( label, "some-id" ) ( "label", "some-id" )
+        , test "valueText" <|
+            expectAria ( valueText, "Medium on the Range" ) ( "valuetext", "Medium on the Range" )
+        , describe "disabled" <|
+            expectAriaBoolAttribute disabled "disabled"
+        , describe "expanded" <|
+            expectAriaBoolAttribute expanded "expanded"
+        , describe "hidden" <|
+            expectAriaBoolAttribute hidden "hidden"
+        , describe "invalid" <|
+            expectAriaBoolAttribute invalid "invalid"
+        , describe "multiLine" <|
+            expectAriaBoolAttribute multiLine "multiline"
+        , describe "multiSelectable" <|
+            expectAriaBoolAttribute multiSelectable "multiselectable"
+        , describe "readOnly" <|
+            expectAriaBoolAttribute readOnly "readonly"
+        , describe "required" <|
+            expectAriaBoolAttribute required "required"
+        , describe "selected" <|
+            expectAriaBoolAttribute selected "selected"
+        , describe "pressed" <|
+            expectAriaTristateAttribute pressed "pressed"
+        , describe "checked" <|
+            expectAriaTristateAttribute checked "checked"
+        , test "valueMax" <|
+            expectAria ( valueMax, 10 ) ( "valuemax", "10" )
+        , test "valueMin" <|
+            expectAria ( valueMin, 10 ) ( "valuemin", "10" )
+        , test "valueNow" <|
+            expectAria ( valueNow, 10 ) ( "valuenow", "10" )
+        , test "level" <|
+            expectAria ( level, 10 ) ( "level", "10" )
+        , describe "modal" <|
+            expectAriaBoolAttribute modal "modal"
+        ]

--- a/tests/AccessibilitySpec.elm
+++ b/tests/AccessibilitySpec.elm
@@ -1,0 +1,439 @@
+module AccessibilitySpec exposing (htmlSpec, imageSpec, inputSpec)
+
+import Accessibility.Styled exposing (..)
+import Html.Attributes as Attribute
+import Html.Styled exposing (toUnstyled)
+import Html.Styled.Attributes
+import Html.Styled.Events exposing (onClick)
+import Test exposing (..)
+import Test.Html.Event as Event
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+inputSpec : Test
+inputSpec =
+    describe "inputs" <|
+        [ describe "text inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "text"
+                    }
+            in
+            [ describe "labelBefore"
+                [ baseInputTests expected <|
+                    labelBefore []
+                        (text "the label")
+                        (inputText "the value" [])
+                ]
+            , describe "labelAfter"
+                [ baseInputTests expected <|
+                    labelAfter []
+                        (text "the label")
+                        (inputText "the value" [])
+                ]
+            , describe "labelHidden"
+                [ baseInputTests expected <|
+                    labelHidden "id"
+                        []
+                        (text "the label")
+                        (inputText "the value" [])
+                ]
+            ]
+        , describe "radio inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "radio"
+                    }
+            in
+            [ describe "labelBefore"
+                [ baseInputTests expected <|
+                    labelBefore []
+                        (text "the label")
+                        (radio "group_name" "the value" True [])
+                ]
+            , describe "labelAfter"
+                [ baseInputTests expected <|
+                    labelAfter []
+                        (text "the label")
+                        (radio "group_name" "the value" True [])
+                ]
+            , describe "labelHidden"
+                [ baseInputTests expected <|
+                    labelHidden "id"
+                        []
+                        (text "the label")
+                        (radio "group_name" "the value" True [ Html.Styled.Attributes.id "id" ])
+                ]
+            ]
+        , describe "checkbox inputs" <|
+            let
+                expected =
+                    { label = "the label"
+                    , value = "the value"
+                    , type_ = "checkbox"
+                    }
+            in
+            [ describe "labelBefore"
+                [ baseInputTests expected <|
+                    labelBefore []
+                        (text "the label")
+                        (checkbox "the value" (Just True) [])
+                ]
+            , describe "labelAfter"
+                [ baseInputTests expected <|
+                    labelAfter []
+                        (text "the label")
+                        (checkbox "the value" (Just True) [])
+                ]
+            , describe "labelHidden"
+                [ baseInputTests expected <|
+                    labelHidden "id"
+                        []
+                        (text "the label")
+                        (checkbox "the value" (Just True) [ Html.Styled.Attributes.id "id" ])
+                ]
+            ]
+        ]
+
+
+baseInputTests : { label : String, value : String, type_ : String } -> Html msg -> Test
+baseInputTests { label, value, type_ } view =
+    let
+        queryView =
+            div [] [ figure [] [ view ] ]
+                |> toUnstyled
+                |> Query.fromHtml
+    in
+    describe "Basic input tests"
+        [ test "has label with the given label text" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "label" ]
+                    |> Query.has [ Selector.text label ]
+        , test "has input with the appropriate value" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "input" ]
+                    |> Query.has [ Selector.attribute <| Attribute.value value ]
+        , test "is an input of the appropriate type" <|
+            \() ->
+                queryView
+                    |> Query.find [ Selector.tag "input" ]
+                    |> Query.has [ Selector.attribute <| Attribute.type_ type_ ]
+        ]
+
+
+imageSpec : Test
+imageSpec =
+    let
+        queryView view =
+            div [] [ Accessibility.Styled.figure [] [ view ] ]
+                |> toUnstyled
+                |> Query.fromHtml
+                |> Query.find [ Selector.tag "img" ]
+    in
+    describe "images"
+        [ describe "img"
+            [ test "has alt text" <|
+                \() ->
+                    queryView (Accessibility.Styled.img "Birthday cake" [])
+                        |> Query.has [ Selector.attribute <| Attribute.alt "Birthday cake" ]
+            ]
+        , describe "decorativeImg"
+            [ test "has empty alt text" <|
+                \() ->
+                    queryView (decorativeImg [])
+                        |> Query.has [ Selector.attribute <| Attribute.alt "" ]
+            ]
+        ]
+
+
+type Msg
+    = DoAThing
+
+
+htmlSpec : Test
+htmlSpec =
+    let
+        expectClickableChild element =
+            div [] [ element [] [ button [ onClick DoAThing ] [] ] ]
+                |> toUnstyled
+                |> Query.fromHtml
+                |> Query.find [ Selector.tag "button" ]
+                |> Event.simulate Event.click
+                |> Event.expect DoAThing
+    in
+    describe "aliased elements without event listener support"
+        [ test "section" <|
+            \() ->
+                expectClickableChild section
+        , test "nav" <|
+            \() ->
+                expectClickableChild nav
+        , test "article" <|
+            \() ->
+                expectClickableChild article
+        , test "aside" <|
+            \() ->
+                expectClickableChild aside
+        , test "h1" <|
+            \() ->
+                expectClickableChild h1
+        , test "h2" <|
+            \() ->
+                expectClickableChild h2
+        , test "h3" <|
+            \() ->
+                expectClickableChild h3
+        , test "h4" <|
+            \() ->
+                expectClickableChild h4
+        , test "h5" <|
+            \() ->
+                expectClickableChild h5
+        , test "h6" <|
+            \() ->
+                expectClickableChild h6
+        , test "header" <|
+            \() ->
+                expectClickableChild header
+        , test "footer" <|
+            \() ->
+                expectClickableChild footer
+        , test "address" <|
+            \() ->
+                expectClickableChild address
+        , test "main_" <|
+            \() ->
+                expectClickableChild main_
+        , test "p" <|
+            \() ->
+                expectClickableChild p
+        , test "hr" <|
+            \() ->
+                expectClickableChild hr
+        , test "pre" <|
+            \() ->
+                expectClickableChild pre
+        , test "blockquote" <|
+            \() ->
+                expectClickableChild blockquote
+        , test "ol" <|
+            \() ->
+                expectClickableChild ol
+        , test "ul" <|
+            \() ->
+                expectClickableChild ul
+        , test "li" <|
+            \() ->
+                expectClickableChild li
+        , test "dl" <|
+            \() ->
+                expectClickableChild dl
+        , test "dt" <|
+            \() ->
+                expectClickableChild dt
+        , test "dd" <|
+            \() ->
+                expectClickableChild dd
+        , test "figcaption" <|
+            \() ->
+                expectClickableChild figcaption
+        , test "div" <|
+            \() ->
+                expectClickableChild div
+        , test "em" <|
+            \() ->
+                expectClickableChild em
+        , test "strong" <|
+            \() ->
+                expectClickableChild strong
+        , test "small" <|
+            \() ->
+                expectClickableChild small
+        , test "s" <|
+            \() ->
+                expectClickableChild s
+        , test "cite" <|
+            \() ->
+                expectClickableChild cite
+        , test "q" <|
+            \() ->
+                expectClickableChild q
+        , test "dfn" <|
+            \() ->
+                expectClickableChild dfn
+        , test "abbr" <|
+            \() ->
+                expectClickableChild abbr
+        , test "time" <|
+            \() ->
+                expectClickableChild time
+        , test "code" <|
+            \() ->
+                expectClickableChild code
+        , test "var" <|
+            \() ->
+                expectClickableChild var
+        , test "samp" <|
+            \() ->
+                expectClickableChild samp
+        , test "kbd" <|
+            \() ->
+                expectClickableChild kbd
+        , test "sub" <|
+            \() ->
+                expectClickableChild sub
+        , test "sup" <|
+            \() ->
+                expectClickableChild sup
+        , test "i" <|
+            \() ->
+                expectClickableChild i
+        , test "b" <|
+            \() ->
+                expectClickableChild b
+        , test "u" <|
+            \() ->
+                expectClickableChild u
+        , test "mark" <|
+            \() ->
+                expectClickableChild mark
+        , test "ruby" <|
+            \() ->
+                expectClickableChild ruby
+        , test "rt" <|
+            \() ->
+                expectClickableChild rt
+        , test "rp" <|
+            \() ->
+                expectClickableChild rp
+        , test "bdi" <|
+            \() ->
+                expectClickableChild bdi
+        , test "bdo" <|
+            \() ->
+                expectClickableChild bdo
+        , test "span" <|
+            \() ->
+                expectClickableChild span
+        , test "wbr" <|
+            \() ->
+                expectClickableChild wbr
+        , test "ins" <|
+            \() ->
+                expectClickableChild ins
+        , test "del" <|
+            \() ->
+                expectClickableChild del
+        , test "iframe" <|
+            \() ->
+                expectClickableChild iframe
+        , test "embed" <|
+            \() ->
+                expectClickableChild embed
+        , test "object" <|
+            \() ->
+                expectClickableChild object
+        , test "param" <|
+            \() ->
+                expectClickableChild param
+        , test "video" <|
+            \() ->
+                expectClickableChild video
+        , test "audio" <|
+            \() ->
+                expectClickableChild audio
+        , test "source" <|
+            \() ->
+                expectClickableChild source
+        , test "track" <|
+            \() ->
+                expectClickableChild track
+        , test "canvas" <|
+            \() ->
+                expectClickableChild canvas
+        , test "math" <|
+            \() ->
+                expectClickableChild math
+        , test "table" <|
+            \() ->
+                expectClickableChild table
+        , test "caption" <|
+            \() ->
+                expectClickableChild caption
+        , test "colgroup" <|
+            \() ->
+                expectClickableChild colgroup
+        , test "col" <|
+            \() ->
+                expectClickableChild col
+        , test "tbody" <|
+            \() ->
+                expectClickableChild tbody
+        , test "thead" <|
+            \() ->
+                expectClickableChild thead
+        , test "tfoot" <|
+            \() ->
+                expectClickableChild tfoot
+        , test "tr" <|
+            \() ->
+                expectClickableChild tr
+        , test "td" <|
+            \() ->
+                expectClickableChild td
+        , test "th" <|
+            \() ->
+                expectClickableChild th
+        , test "form" <|
+            \() ->
+                expectClickableChild form
+        , test "fieldset" <|
+            \() ->
+                expectClickableChild fieldset
+        , test "legend" <|
+            \() ->
+                expectClickableChild legend
+        , test "label" <|
+            \() ->
+                expectClickableChild label
+        , test "datalist" <|
+            \() ->
+                expectClickableChild datalist
+        , test "optgroup" <|
+            \() ->
+                expectClickableChild optgroup
+        , test "option" <|
+            \() ->
+                expectClickableChild option
+        , test "textarea" <|
+            \() ->
+                expectClickableChild textarea
+        , test "output" <|
+            \() ->
+                expectClickableChild output
+        , test "progress" <|
+            \() ->
+                expectClickableChild progress
+        , test "meter" <|
+            \() ->
+                expectClickableChild meter
+        , test "details" <|
+            \() ->
+                expectClickableChild details
+        , test "summary" <|
+            \() ->
+                expectClickableChild summary
+        , test "menuitem" <|
+            \() ->
+                expectClickableChild menuitem
+        , test "menu" <|
+            \() ->
+                expectClickableChild menu
+        ]

--- a/tests/SpecHelpers.elm
+++ b/tests/SpecHelpers.elm
@@ -1,0 +1,55 @@
+module SpecHelpers exposing (expectAria, expectAriaBoolAttribute, expectAriaTristateAttribute, expectAttribute)
+
+import Expect
+import Html.Attributes
+import Html.Styled as Html exposing (toUnstyled)
+import Json.Encode
+import Test exposing (..)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+expectAriaBoolAttribute : (Bool -> Html.Attribute msg) -> String -> List Test
+expectAriaBoolAttribute setter attribute =
+    [ test "True" <| expectAria ( setter, True ) ( attribute, "true" )
+    , test "False" <| expectAria ( setter, False ) ( attribute, "false" )
+    ]
+
+
+expectAriaTristateAttribute : (Maybe Bool -> Html.Attribute msg) -> String -> List Test
+expectAriaTristateAttribute setter attribute =
+    [ test "True" <| expectAria ( setter, Just True ) ( attribute, "true" )
+    , test "False" <| expectAria ( setter, Just False ) ( attribute, "false" )
+    , test "Mixed" <| expectAria ( setter, Nothing ) ( attribute, "mixed" )
+    ]
+
+
+expectAria :
+    ( a -> Html.Attribute msg, a )
+    -> ( String, String )
+    -> ()
+    -> Expect.Expectation
+expectAria ( setter, state ) ( attribute, attrState ) =
+    expectAttribute ( setter, state ) ( "aria-" ++ attribute, attrState )
+
+
+expectAttribute :
+    ( a -> Html.Attribute msg, a )
+    -> ( String, String )
+    -> ()
+    -> Expect.Expectation
+expectAttribute ( setter, state ) ( attribute, attrState ) =
+    \() ->
+        Html.div [] [ Html.div [ setter state ] [] ]
+            |> toUnstyled
+            |> Query.fromHtml
+            |> hasAttribute attribute attrState
+
+
+hasAttribute : String -> String -> Query.Single msg -> Expect.Expectation
+hasAttribute attribute state =
+    Query.has
+        [ Selector.attribute <|
+            Html.Attributes.property attribute
+                (Json.Encode.string state)
+        ]


### PR DESCRIPTION
This just re-adds the tests that existed before 32247e47c849df34858de48e3563c8218580aaf9 with some minor changes, i.e. updating `elm.json` and removing `body` and `keygen`.