### PR TITLE
Adds onKeyDownPreventDefault, onKeyUp, onKeyUpPreventDefault

### DIFF
--- a/src/Accessibility/Styled/Key.elm
+++ b/src/Accessibility/Styled/Key.elm
@@ -1,6 +1,7 @@
 module Accessibility.Styled.Key exposing
     ( tabbable
-    , onKeyDown
+    , onKeyDown, onKeyDownPreventDefault
+    , onKeyUp, onKeyUpPreventDefault
     , tab, tabBack
     , up, right, down, left
     , enter, space
@@ -17,7 +18,8 @@ module Accessibility.Styled.Key exposing
 
 ## Keyboard event listener
 
-@docs onKeyDown
+@docs onKeyDown, onKeyDownPreventDefault
+@docs onKeyUp, onKeyUpPreventDefault
 
 
 ## Decoders
@@ -43,7 +45,7 @@ module Accessibility.Styled.Key exposing
 
 import Html.Styled as Html exposing (Attribute)
 import Html.Styled.Attributes
-import Html.Styled.Events exposing (keyCode, on)
+import Html.Styled.Events exposing (keyCode, on, preventDefaultOn)
 import Json.Decode as Json
 
 
@@ -71,6 +73,44 @@ tabbable isTabbable =
 onKeyDown : List (Json.Decoder msg) -> Attribute msg
 onKeyDown decoders =
     on "keydown" (Json.oneOf decoders)
+
+
+{-| Pass a list of decoders.
+
+    onKeyDownPreventDefault [ space TheyHitEnterDoSomethingButDontScrollThePage ]
+
+-}
+onKeyDownPreventDefault : List (Json.Decoder msg) -> Attribute msg
+onKeyDownPreventDefault decoders =
+    alwaysPreventDefault "keydown" decoders
+
+
+{-| Pass a list of decoders.
+
+    onKeyUp [ enter TheyHitEnterDoSomething, left DoSomeOtherThing ]
+
+-}
+onKeyUp : List (Json.Decoder msg) -> Attribute msg
+onKeyUp decoders =
+    on "keyup" (Json.oneOf decoders)
+
+
+{-| Pass a list of decoders.
+
+    onKeyUpPreventDefault [ space TheyHitEnterDoSomethingButDontScrollThePage ]
+
+-}
+onKeyUpPreventDefault : List (Json.Decoder msg) -> Attribute msg
+onKeyUpPreventDefault decoders =
+    alwaysPreventDefault "keyup" decoders
+
+
+alwaysPreventDefault : String -> List (Json.Decoder msg) -> Attribute msg
+alwaysPreventDefault event decoders =
+    decoders
+        |> List.map (Json.map (\decoder -> ( decoder, True )))
+        |> Json.oneOf
+        |> preventDefaultOn event
 
 
 

--- a/tests/Accessibility/KeySpec.elm
+++ b/tests/Accessibility/KeySpec.elm
@@ -2,6 +2,7 @@ module Accessibility.KeySpec exposing (spec)
 
 import Accessibility.Styled.Key exposing (..)
 import Html.Styled exposing (..)
+import Json.Decode exposing (Decoder)
 import Json.Encode as Encode
 import SpecHelpers exposing (expectAttribute)
 import Test exposing (..)
@@ -42,18 +43,46 @@ keys =
 
 expectEvent : String -> Encode.Value -> Msg -> Test
 expectEvent name keyState msg =
-    test (name ++ " produces " ++ msgToString msg) <|
-        \() ->
-            view
-                |> toUnstyled
-                |> Query.fromHtml
-                |> Event.simulate (keydown keyState)
-                |> Event.expect msg
+    describe (name ++ " produces " ++ msgToString msg)
+        [ test "onKeyDown" <|
+            \() ->
+                view onKeyDown
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Event.simulate (keydown keyState)
+                    |> Event.expect msg
+        , test "onKeyDownPreventDefault" <|
+            \() ->
+                view onKeyDownPreventDefault
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Event.simulate (keydown keyState)
+                    |> Event.expect msg
+        , test "onKeyUp" <|
+            \() ->
+                view onKeyUp
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Event.simulate (keyup keyState)
+                    |> Event.expect msg
+        , test "onKeyUpPreventDefault" <|
+            \() ->
+                view onKeyUpPreventDefault
+                    |> toUnstyled
+                    |> Query.fromHtml
+                    |> Event.simulate (keyup keyState)
+                    |> Event.expect msg
+        ]
 
 
 keydown : Encode.Value -> ( String, Encode.Value )
 keydown =
     Event.custom "keydown"
+
+
+keyup : Encode.Value -> ( String, Encode.Value )
+keyup =
+    Event.custom "keyup"
 
 
 withKey : Int -> Encode.Value
@@ -76,10 +105,10 @@ shiftKey pressed =
     ( "shiftKey", Encode.bool pressed )
 
 
-view : Html Msg
-view =
+view : (List (Decoder Msg) -> Attribute Msg) -> Html Msg
+view listener =
     div
-        [ onKeyDown
+        [ listener
             [ left Left
             , up Up
             , right Right


### PR DESCRIPTION
The default behavior of the spacebar scrolls the page, so often we'll want to prevent default when adding spacebar-based custom events.

Also, using keyup is frequently better than keydown, since it can give users a chance to "cancel" actions by moving their cursor.