### PR TITLE
Adds shift-arrow decoders

### DIFF
--- a/src/Accessibility/Styled/Key.elm
+++ b/src/Accessibility/Styled/Key.elm
@@ -4,6 +4,7 @@ module Accessibility.Styled.Key exposing
     , onKeyUp, onKeyUpPreventDefault
     , tab, tabBack
     , up, right, down, left
+    , shiftUp, shiftRight, shiftDown, shiftLeft
     , enter, space
     , escape
     )
@@ -30,6 +31,7 @@ module Accessibility.Styled.Key exposing
 @docs tab, tabBack
 
 @docs up, right, down, left
+@docs shiftUp, shiftRight, shiftDown, shiftLeft
 
 
 ### Activation
@@ -155,44 +157,84 @@ escape msg =
 -- ARROW KEYS
 
 
-{-| Use with `onKeyDown` to succeed when user hits the left arrow key.
+{-| Use with `onKeyDown` to succeed when user hits the left arrow key without the shift key.
 
     onKeyDown [ left Left ]
 
 -}
 left : msg -> Json.Decoder msg
 left msg =
-    succeedForKeyCode 37 msg
+    succeedForKeyCodeWithoutModifier 37 shiftKey msg
 
 
-{-| Use with `onKeyDown` to succeed when user hits the up arrow key.
+{-| Use with `onKeyDown` to succeed when user hits the up arrow key without the shift key.
 
     onKeyDown [ up Up ]
 
 -}
 up : msg -> Json.Decoder msg
 up msg =
-    succeedForKeyCode 38 msg
+    succeedForKeyCodeWithoutModifier 38 shiftKey msg
 
 
-{-| Use with `onKeyDown` to succeed when user hits the right arrow key.
+{-| Use with `onKeyDown` to succeed when user hits the right arrow key without the shift key.
 
     onKeyDown [ right Right ]
 
 -}
 right : msg -> Json.Decoder msg
 right msg =
-    succeedForKeyCode 39 msg
+    succeedForKeyCodeWithoutModifier 39 shiftKey msg
 
 
-{-| Use with `onKeyDown` to succeed when user hits the down arrow key.
+{-| Use with `onKeyDown` to succeed when user hits the down arrow key without the shift key.
 
     onKeyDown [ down Down ]
 
 -}
 down : msg -> Json.Decoder msg
 down msg =
-    succeedForKeyCode 40 msg
+    succeedForKeyCodeWithoutModifier 40 shiftKey msg
+
+
+{-| Succeed when user hits the left arrow key with the shift key.
+
+    onKeyDown [ shiftLeft Left ]
+
+-}
+shiftLeft : msg -> Json.Decoder msg
+shiftLeft msg =
+    succeedForKeyCodeWithModifier 37 shiftKey msg
+
+
+{-| Succeed when user hits the up arrow key with the shift key.
+
+    onKeyDown [ shiftUp Up ]
+
+-}
+shiftUp : msg -> Json.Decoder msg
+shiftUp msg =
+    succeedForKeyCodeWithModifier 38 shiftKey msg
+
+
+{-| Succeed when user hits the right arrow key with the shift key.
+
+    onKeyDown [ shiftRight Right ]
+
+-}
+shiftRight : msg -> Json.Decoder msg
+shiftRight msg =
+    succeedForKeyCodeWithModifier 39 shiftKey msg
+
+
+{-| Succeed when user hits the down arrow key with the shift key.
+
+    onKeyDown [ shiftDown Down ]
+
+-}
+shiftDown : msg -> Json.Decoder msg
+shiftDown msg =
+    succeedForKeyCodeWithModifier 40 shiftKey msg
 
 
 

--- a/tests/Accessibility/KeySpec.elm
+++ b/tests/Accessibility/KeySpec.elm
@@ -29,11 +29,18 @@ tabbableSpec =
 
 keys : List Test
 keys =
-    [ expectEvent "left key" (withKey 37) Left
+    [ -- arrows
+      expectEvent "left key" (withKey 37) Left
     , expectEvent "up key" (withKey 38) Up
     , expectEvent "right key" (withKey 39) Right
     , expectEvent "down key" (withKey 40) Down
-    , expectEvent "enter key" (withKey 13) Enter
+    , -- arrows with shift
+      expectEvent "left key+shift" (withShiftAndKey 37) ShiftLeft
+    , expectEvent "up key+shift" (withShiftAndKey 38) ShiftUp
+    , expectEvent "right key+shift" (withShiftAndKey 39) ShiftRight
+    , expectEvent "down key+shift" (withShiftAndKey 40) ShiftDown
+    , -- other
+      expectEvent "enter key" (withKey 13) Enter
     , expectEvent "spacebar" (withKey 32) SpaceBar
     , expectEvent "tab key" (withKey 9) Tab
     , expectEvent "tab+shift" (withShiftAndKey 9) TabBack
@@ -113,6 +120,10 @@ view listener =
             , up Up
             , right Right
             , down Down
+            , shiftLeft ShiftLeft
+            , shiftUp ShiftUp
+            , shiftRight ShiftRight
+            , shiftDown ShiftDown
             , enter Enter
             , tab Tab
             , tabBack TabBack
@@ -128,6 +139,10 @@ type Msg
     | Up
     | Right
     | Down
+    | ShiftLeft
+    | ShiftUp
+    | ShiftRight
+    | ShiftDown
     | Enter
     | Tab
     | TabBack
@@ -149,6 +164,18 @@ msgToString msg =
 
         Down ->
             "Down"
+
+        ShiftLeft ->
+            "ShiftLeft"
+
+        ShiftUp ->
+            "ShiftUp"
+
+        ShiftRight ->
+            "ShiftRight"
+
+        ShiftDown ->
+            "ShiftDown"
 
         Enter ->
             "Enter"


### PR DESCRIPTION
Note that this ALSO changes the current arrow decoders to fail if shift is also pressed.

```
This is a MINOR change.

---- Accessibility.Styled.Key - MINOR ----

    Added:
        shiftDown : msg -> Json.Decode.Decoder msg
        shiftLeft : msg -> Json.Decode.Decoder msg
        shiftRight : msg -> Json.Decode.Decoder msg
        shiftUp : msg -> Json.Decode.Decoder msg
```