### PR TITLE
Change key implementation

### DIFF
--- a/src/Accessibility/Styled/Key.elm
+++ b/src/Accessibility/Styled/Key.elm
@@ -4,6 +4,7 @@ module Accessibility.Styled.Key exposing
     , onKeyUp, onKeyUpPreventDefault
     , tab, tabBack
     , up, right, down, left
+    , shift
     , shiftUp, shiftRight, shiftDown, shiftLeft
     , enter, space
     , escape
@@ -31,6 +32,7 @@ module Accessibility.Styled.Key exposing
 @docs tab, tabBack
 
 @docs up, right, down, left
+@docs shift
 @docs shiftUp, shiftRight, shiftDown, shiftLeft
 
 
@@ -195,6 +197,16 @@ right msg =
 down : msg -> Json.Decoder msg
 down msg =
     succeedForKeyCodeWithoutModifier 40 shiftKey msg
+
+
+{-| Succeed when user hits the shift key by itself.
+
+    onKeyDown [ shift Shift ]
+
+-}
+shift : msg -> Json.Decoder msg
+shift msg =
+    succeedForKeyCodeWithModifier 16 shiftKey msg
 
 
 {-| Succeed when user hits the left arrow key with the shift key.

--- a/src/Accessibility/Styled/Key.elm
+++ b/src/Accessibility/Styled/Key.elm
@@ -2,6 +2,7 @@ module Accessibility.Styled.Key exposing
     ( tabbable
     , onKeyDown, onKeyDownPreventDefault
     , onKeyUp, onKeyUpPreventDefault
+    , Event
     , tab, tabBack
     , up, right, down, left
     , shift
@@ -24,7 +25,12 @@ module Accessibility.Styled.Key exposing
 @docs onKeyUp, onKeyUpPreventDefault
 
 
-## Decoders
+## Events
+
+Note: the API here is different than in previous versions of this library because of <https://github.com/elm/json/issues/15>.
+A future version of this library may return to using generic decoders.
+
+@docs Event
 
 
 ### Navigation
@@ -50,7 +56,7 @@ module Accessibility.Styled.Key exposing
 import Html.Styled as Html exposing (Attribute)
 import Html.Styled.Attributes
 import Html.Styled.Events as Events exposing (on, preventDefaultOn)
-import Json.Decode as Json
+import Json.Decode as Json exposing (Decoder)
 
 
 {-| Add or remove an element from the normal flow of tabbable/focusable elements.
@@ -69,52 +75,83 @@ tabbable isTabbable =
         Html.Styled.Attributes.tabindex -1
 
 
-{-| Pass a list of decoders.
+{-| -}
+type alias Event msg =
+    { keyCode : Int
+    , shiftKey : Bool
+    , msg : msg
+    }
+
+
+{-| Pass a list of keyboard events to match.
 
     onKeyDown [ enter TheyHitEnterDoSomething, left DoSomeOtherThing ]
 
 -}
-onKeyDown : List (Json.Decoder msg) -> Attribute msg
+onKeyDown : List (Event msg) -> Attribute msg
 onKeyDown decoders =
-    on "keydown" (Json.oneOf decoders)
+    on "keydown" (customOneOf decoders)
 
 
-{-| Pass a list of decoders.
+{-| Pass a list of keyboard events to match.
 
     onKeyDownPreventDefault [ space TheyHitEnterDoSomethingButDontScrollThePage ]
 
 -}
-onKeyDownPreventDefault : List (Json.Decoder msg) -> Attribute msg
+onKeyDownPreventDefault : List (Event msg) -> Attribute msg
 onKeyDownPreventDefault decoders =
     alwaysPreventDefault "keydown" decoders
 
 
-{-| Pass a list of decoders.
+{-| Pass a list of keyboard events to match.
 
     onKeyUp [ enter TheyHitEnterDoSomething, left DoSomeOtherThing ]
 
 -}
-onKeyUp : List (Json.Decoder msg) -> Attribute msg
+onKeyUp : List (Event msg) -> Attribute msg
 onKeyUp decoders =
-    on "keyup" (Json.oneOf decoders)
+    on "keyup" (customOneOf decoders)
 
 
-{-| Pass a list of decoders.
+{-| Pass a list of keyboard events to match.
 
     onKeyUpPreventDefault [ space TheyHitEnterDoSomethingButDontScrollThePage ]
 
 -}
-onKeyUpPreventDefault : List (Json.Decoder msg) -> Attribute msg
+onKeyUpPreventDefault : List (Event msg) -> Attribute msg
 onKeyUpPreventDefault decoders =
     alwaysPreventDefault "keyup" decoders
 
 
-alwaysPreventDefault : String -> List (Json.Decoder msg) -> Attribute msg
+alwaysPreventDefault : String -> List (Event msg) -> Attribute msg
 alwaysPreventDefault event decoders =
     decoders
-        |> List.map (Json.map (\decoder -> ( decoder, True )))
-        |> Json.oneOf
+        |> customOneOf
+        |> Json.map (\decoder -> ( decoder, True ))
         |> preventDefaultOn event
+
+
+{-| This exists because Json.Decode.oneOf is broken in a way that causes weird & hard-to-diagnose bugs.
+-}
+customOneOf : List (Event msg) -> Decoder msg
+customOneOf events =
+    let
+        justMatches keyCode shiftKey event =
+            if event.keyCode == keyCode && shiftKey == event.shiftKey then
+                Just event.msg
+
+            else
+                Nothing
+    in
+    Json.map2
+        (\keyCode shiftKey ->
+            events
+                |> List.filterMap (justMatches keyCode shiftKey)
+                |> List.head
+        )
+        Events.keyCode
+        (Json.field "shiftKey" Json.bool)
+        |> Json.andThen (Maybe.map Json.succeed >> Maybe.withDefault (Json.fail "No matches"))
 
 
 
@@ -126,9 +163,12 @@ alwaysPreventDefault event decoders =
     onKeyDown [ enter TheyHitEnterDoSomething ]
 
 -}
-enter : msg -> Json.Decoder msg
+enter : msg -> Event msg
 enter msg =
-    succeedForKeyCode 13 msg
+    { keyCode = 13
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Use with `onKeyDown` to succeed when user hits the spacebar.
@@ -136,9 +176,12 @@ enter msg =
     onKeyDown [ space SpaceBar ]
 
 -}
-space : msg -> Json.Decoder msg
+space : msg -> Event msg
 space msg =
-    succeedForKeyCode 32 msg
+    { keyCode = 32
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 
@@ -150,9 +193,12 @@ space msg =
     onKeyDown [ escape CloseModal ]
 
 -}
-escape : msg -> Json.Decoder msg
+escape : msg -> Event msg
 escape msg =
-    succeedForKeyCode 27 msg
+    { keyCode = 27
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 
@@ -164,9 +210,12 @@ escape msg =
     onKeyDown [ left Left ]
 
 -}
-left : msg -> Json.Decoder msg
+left : msg -> Event msg
 left msg =
-    succeedForKeyCodeWithoutModifier 37 shiftKey msg
+    { keyCode = 37
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Use with `onKeyDown` to succeed when user hits the up arrow key without the shift key.
@@ -174,9 +223,12 @@ left msg =
     onKeyDown [ up Up ]
 
 -}
-up : msg -> Json.Decoder msg
+up : msg -> Event msg
 up msg =
-    succeedForKeyCodeWithoutModifier 38 shiftKey msg
+    { keyCode = 38
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Use with `onKeyDown` to succeed when user hits the right arrow key without the shift key.
@@ -184,9 +236,12 @@ up msg =
     onKeyDown [ right Right ]
 
 -}
-right : msg -> Json.Decoder msg
+right : msg -> Event msg
 right msg =
-    succeedForKeyCodeWithoutModifier 39 shiftKey msg
+    { keyCode = 39
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Use with `onKeyDown` to succeed when user hits the down arrow key without the shift key.
@@ -194,9 +249,12 @@ right msg =
     onKeyDown [ down Down ]
 
 -}
-down : msg -> Json.Decoder msg
+down : msg -> Event msg
 down msg =
-    succeedForKeyCodeWithoutModifier 40 shiftKey msg
+    { keyCode = 40
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Succeed when user hits the shift key by itself.
@@ -204,9 +262,12 @@ down msg =
     onKeyDown [ shift Shift ]
 
 -}
-shift : msg -> Json.Decoder msg
+shift : msg -> Event msg
 shift msg =
-    succeedForKeyCodeWithModifier 16 shiftKey msg
+    { keyCode = 16
+    , shiftKey = True
+    , msg = msg
+    }
 
 
 {-| Succeed when user hits the left arrow key with the shift key.
@@ -214,9 +275,12 @@ shift msg =
     onKeyDown [ shiftLeft Left ]
 
 -}
-shiftLeft : msg -> Json.Decoder msg
+shiftLeft : msg -> Event msg
 shiftLeft msg =
-    succeedForKeyCodeWithModifier 37 shiftKey msg
+    { keyCode = 37
+    , shiftKey = True
+    , msg = msg
+    }
 
 
 {-| Succeed when user hits the up arrow key with the shift key.
@@ -224,9 +288,12 @@ shiftLeft msg =
     onKeyDown [ shiftUp Up ]
 
 -}
-shiftUp : msg -> Json.Decoder msg
+shiftUp : msg -> Event msg
 shiftUp msg =
-    succeedForKeyCodeWithModifier 38 shiftKey msg
+    { keyCode = 38
+    , shiftKey = True
+    , msg = msg
+    }
 
 
 {-| Succeed when user hits the right arrow key with the shift key.
@@ -234,9 +301,12 @@ shiftUp msg =
     onKeyDown [ shiftRight Right ]
 
 -}
-shiftRight : msg -> Json.Decoder msg
+shiftRight : msg -> Event msg
 shiftRight msg =
-    succeedForKeyCodeWithModifier 39 shiftKey msg
+    { keyCode = 39
+    , shiftKey = True
+    , msg = msg
+    }
 
 
 {-| Succeed when user hits the down arrow key with the shift key.
@@ -244,9 +314,12 @@ shiftRight msg =
     onKeyDown [ shiftDown Down ]
 
 -}
-shiftDown : msg -> Json.Decoder msg
+shiftDown : msg -> Event msg
 shiftDown msg =
-    succeedForKeyCodeWithModifier 40 shiftKey msg
+    { keyCode = 40
+    , shiftKey = True
+    , msg = msg
+    }
 
 
 
@@ -258,9 +331,12 @@ shiftDown msg =
     onKeyDown [ tab Tab ]
 
 -}
-tab : msg -> Json.Decoder msg
+tab : msg -> Event msg
 tab msg =
-    succeedForKeyCodeWithoutModifier 9 shiftKey msg
+    { keyCode = 9
+    , shiftKey = False
+    , msg = msg
+    }
 
 
 {-| Use with `onKeyDown` to succeed when user hits the tab key while hitting shift.
@@ -268,52 +344,9 @@ tab msg =
     onKeyDown [ tabBack GoBack ]
 
 -}
-tabBack : msg -> Json.Decoder msg
+tabBack : msg -> Event msg
 tabBack msg =
-    succeedForKeyCodeWithModifier 9 shiftKey msg
-
-
-
--- KEYCODES
-
-
-succeedForKeyCode : Int -> msg -> Json.Decoder msg
-succeedForKeyCode key msg =
-    Json.andThen (forKeyCode key msg) Events.keyCode
-
-
-forKeyCode : Int -> msg -> Int -> Json.Decoder msg
-forKeyCode key msg keyCode =
-    if keyCode == key then
-        Json.succeed msg
-
-    else
-        Json.fail (String.fromInt keyCode)
-
-
-
--- SHIFT and other modifiers
-
-
-succeedForKeyCodeWithModifier : Int -> Json.Decoder Bool -> msg -> Json.Decoder msg
-succeedForKeyCodeWithModifier key decodeModifier msg =
-    Json.andThen (forModifier key msg identity) decodeModifier
-
-
-succeedForKeyCodeWithoutModifier : Int -> Json.Decoder Bool -> msg -> Json.Decoder msg
-succeedForKeyCodeWithoutModifier key decodeModifier msg =
-    Json.andThen (forModifier key msg not) decodeModifier
-
-
-forModifier : Int -> a -> (Bool -> Bool) -> Bool -> Json.Decoder a
-forModifier key msg withModifierPressed modifierKey =
-    if withModifierPressed modifierKey then
-        succeedForKeyCode key msg
-
-    else
-        Json.fail "False"
-
-
-shiftKey : Json.Decoder Bool
-shiftKey =
-    Json.field "shiftKey" Json.bool
+    { keyCode = 9
+    , shiftKey = True
+    , msg = msg
+    }

--- a/src/Accessibility/Styled/Key.elm
+++ b/src/Accessibility/Styled/Key.elm
@@ -47,7 +47,7 @@ module Accessibility.Styled.Key exposing
 
 import Html.Styled as Html exposing (Attribute)
 import Html.Styled.Attributes
-import Html.Styled.Events exposing (keyCode, on, preventDefaultOn)
+import Html.Styled.Events as Events exposing (on, preventDefaultOn)
 import Json.Decode as Json
 
 
@@ -267,7 +267,7 @@ tabBack msg =
 
 succeedForKeyCode : Int -> msg -> Json.Decoder msg
 succeedForKeyCode key msg =
-    Json.andThen (forKeyCode key msg) keyCode
+    Json.andThen (forKeyCode key msg) Events.keyCode
 
 
 forKeyCode : Int -> msg -> Int -> Json.Decoder msg

--- a/tests/Accessibility/KeySpec.elm
+++ b/tests/Accessibility/KeySpec.elm
@@ -30,27 +30,29 @@ tabbableSpec =
 keys : List Test
 keys =
     [ -- arrows
-      expectEvent "left key" (withKey 37) Left
-    , expectEvent "up key" (withKey 38) Up
-    , expectEvent "right key" (withKey 39) Right
-    , expectEvent "down key" (withKey 40) Down
+      expectEvent "left key" (withKey 37) "Left"
+    , expectEvent "up key" (withKey 38) "Up"
+    , expectEvent "right key" (withKey 39) "Right"
+    , expectEvent "down key" (withKey 40) "Down"
+    , -- shift
+      expectEvent "shift" (withShiftAndKey 16) "Shift"
     , -- arrows with shift
-      expectEvent "left key+shift" (withShiftAndKey 37) ShiftLeft
-    , expectEvent "up key+shift" (withShiftAndKey 38) ShiftUp
-    , expectEvent "right key+shift" (withShiftAndKey 39) ShiftRight
-    , expectEvent "down key+shift" (withShiftAndKey 40) ShiftDown
+      expectEvent "left key+shift" (withShiftAndKey 37) "ShiftLeft"
+    , expectEvent "up key+shift" (withShiftAndKey 38) "ShiftUp"
+    , expectEvent "right key+shift" (withShiftAndKey 39) "ShiftRight"
+    , expectEvent "down key+shift" (withShiftAndKey 40) "ShiftDown"
     , -- other
-      expectEvent "enter key" (withKey 13) Enter
-    , expectEvent "spacebar" (withKey 32) SpaceBar
-    , expectEvent "tab key" (withKey 9) Tab
-    , expectEvent "tab+shift" (withShiftAndKey 9) TabBack
-    , expectEvent "escape key" (withKey 27) Escape
+      expectEvent "enter key" (withKey 13) "Enter"
+    , expectEvent "spacebar" (withKey 32) "SpaceBar"
+    , expectEvent "tab key" (withKey 9) "Tab"
+    , expectEvent "tab+shift" (withShiftAndKey 9) "TabBack"
+    , expectEvent "escape key" (withKey 27) "Escape"
     ]
 
 
-expectEvent : String -> Encode.Value -> Msg -> Test
+expectEvent : String -> Encode.Value -> String -> Test
 expectEvent name keyState msg =
-    describe (name ++ " produces " ++ msgToString msg)
+    describe (name ++ " produces " ++ msg)
         [ test "onKeyDown" <|
             \() ->
                 view onKeyDown
@@ -112,82 +114,24 @@ shiftKey pressed =
     ( "shiftKey", Encode.bool pressed )
 
 
-view : (List (Decoder Msg) -> Attribute Msg) -> Html Msg
+view : (List (Decoder String) -> Attribute String) -> Html String
 view listener =
     div
         [ listener
-            [ left Left
-            , up Up
-            , right Right
-            , down Down
-            , shiftLeft ShiftLeft
-            , shiftUp ShiftUp
-            , shiftRight ShiftRight
-            , shiftDown ShiftDown
-            , enter Enter
-            , tab Tab
-            , tabBack TabBack
-            , space SpaceBar
-            , escape Escape
+            [ left "Left"
+            , up "Up"
+            , right "Right"
+            , down "Down"
+            , shift "Shift"
+            , shiftLeft "ShiftLeft"
+            , shiftUp "ShiftUp"
+            , shiftRight "ShiftRight"
+            , shiftDown "ShiftDown"
+            , enter "Enter"
+            , tab "Tab"
+            , tabBack "TabBack"
+            , space "SpaceBar"
+            , escape "Escape"
             ]
         ]
         []
-
-
-type Msg
-    = Left
-    | Up
-    | Right
-    | Down
-    | ShiftLeft
-    | ShiftUp
-    | ShiftRight
-    | ShiftDown
-    | Enter
-    | Tab
-    | TabBack
-    | SpaceBar
-    | Escape
-
-
-msgToString : Msg -> String
-msgToString msg =
-    case msg of
-        Left ->
-            "Left"
-
-        Up ->
-            "Up"
-
-        Right ->
-            "Right"
-
-        Down ->
-            "Down"
-
-        ShiftLeft ->
-            "ShiftLeft"
-
-        ShiftUp ->
-            "ShiftUp"
-
-        ShiftRight ->
-            "ShiftRight"
-
-        ShiftDown ->
-            "ShiftDown"
-
-        Enter ->
-            "Enter"
-
-        Tab ->
-            "Tab"
-
-        TabBack ->
-            "TabBack"
-
-        SpaceBar ->
-            "SpaceBar"
-
-        Escape ->
-            "Escape"

--- a/tests/Accessibility/KeySpec.elm
+++ b/tests/Accessibility/KeySpec.elm
@@ -114,7 +114,7 @@ shiftKey pressed =
     ( "shiftKey", Encode.bool pressed )
 
 
-view : (List (Decoder String) -> Attribute String) -> Html String
+view : (List (Event String) -> Attribute String) -> Html String
 view listener =
     div
         [ listener


### PR DESCRIPTION
Json.Decode.oneOf is not safe to use due to https://github.com/elm/json/issues/15. This PR changes Key to avoid using it entirely.

This PR will cause a major bump:

```
---- Accessibility.Styled.Key - MAJOR ----

    Added:
        type alias Event msg =
            { keyCode : Basics.Int, shiftKey : Basics.Bool, msg : msg }
        shift : msg -> Accessibility.Styled.Key.Event msg

    Changed:
      - down : msg -> Decoder msg
      + down : msg -> Accessibility.Styled.Key.Event msg

      - enter : msg -> Decoder msg
      + enter : msg -> Accessibility.Styled.Key.Event msg

      - escape : msg -> Decoder msg
      + escape : msg -> Accessibility.Styled.Key.Event msg

      - left : msg -> Decoder msg
      + left : msg -> Accessibility.Styled.Key.Event msg

      - onKeyDown : List (Decoder msg) -> Attribute msg
      + onKeyDown :
            List.List (Accessibility.Styled.Key.Event msg)
            -> Html.Styled.Attribute msg

      - onKeyDownPreventDefault : List (Decoder msg) -> Attribute msg
      + onKeyDownPreventDefault :
            List.List (Accessibility.Styled.Key.Event msg)
            -> Html.Styled.Attribute msg

      - onKeyUp : List (Decoder msg) -> Attribute msg
      + onKeyUp :
            List.List (Accessibility.Styled.Key.Event msg)
            -> Html.Styled.Attribute msg

      - onKeyUpPreventDefault : List (Decoder msg) -> Attribute msg
      + onKeyUpPreventDefault :
            List.List (Accessibility.Styled.Key.Event msg)
            -> Html.Styled.Attribute msg

      - right : msg -> Decoder msg
      + right : msg -> Accessibility.Styled.Key.Event msg

      - shiftDown : msg -> Decoder msg
      + shiftDown : msg -> Accessibility.Styled.Key.Event msg

      - shiftLeft : msg -> Decoder msg
      + shiftLeft : msg -> Accessibility.Styled.Key.Event msg

      - shiftRight : msg -> Decoder msg
      + shiftRight : msg -> Accessibility.Styled.Key.Event msg

      - shiftUp : msg -> Decoder msg
      + shiftUp : msg -> Accessibility.Styled.Key.Event msg

      - space : msg -> Decoder msg
      + space : msg -> Accessibility.Styled.Key.Event msg

      - tab : msg -> Decoder msg
      + tab : msg -> Accessibility.Styled.Key.Event msg

      - tabBack : msg -> Decoder msg
      + tabBack : msg -> Accessibility.Styled.Key.Event msg

      - up : msg -> Decoder msg
      + up : msg -> Accessibility.Styled.Key.Event msg

```

Upgrading ought to be relatively straightforward, despite the type changes.